### PR TITLE
Added accept header for loadJSON and loadSPARQL

### DIFF
--- a/lib/load-data.js
+++ b/lib/load-data.js
@@ -25,13 +25,13 @@ function loadCSV(url) {
   return d3.csv(url);
 }
 
-async function loadJSON(url) {
-  const res = await fetch(url);
+async function loadJSON(url, accept = 'application/json') {
+  const res = await fetch(url, { headers: { 'Accept': accept } });
   return await res.json();
 }
 
 async function loadSPARQL(url) {
-  const json = await loadJSON(url);
+  const json = await loadJSON(url, 'application/sparql-results+json');
   return sparql2table(json);
 }
 


### PR DESCRIPTION
Added the `Accept: 'application/sparql-results+json'` header for endpoints which return SPARQL results in XML by default.