### PR TITLE
Use `* 1.5` to avoid using deprecated operator `/`

### DIFF
--- a/stanzas/scroll-table/style.scss
+++ b/stanzas/scroll-table/style.scss
@@ -126,8 +126,8 @@
 }
 
 $dot-width: 4px;
-$dot-spacing: $dot-width + $dot-width/2 !default;
 $dot-color: var(--togostanza-tbody-font-color);
+$dot-spacing: $dot-width * 1.5 !default;
 $dot-before-color: $dot-color !default;
 $dot-after-color: $dot-color !default;
 $left-pos: -9999px;


### PR DESCRIPTION
```
DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($dot-width, 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

    ╷
111 │ $dot-spacing: $dot-width + $dot-width/2 !default;
    │                            ^^^^^^^^^^^^
    ╵
    stanzas/scroll-table/style.scss 111:28  root stylesheet