### PR TITLE
Remove obsolete data: gwas_test.json

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,2 @@
 .github
 dist
-assets/gwas_test.json


### PR DESCRIPTION
The Manhattan plot stanza has been moved to OpenStanza, so I think this file should not be here.