### PR TITLE
support for multiple selected nodes

### DIFF
--- a/lib/Legend.js
+++ b/lib/Legend.js
@@ -99,12 +99,15 @@ export default class Legend extends LitElement {
    */
   setup(items, container, opt) {
     this.items = items;
+
     this.render();
     const positions = opt.position || ["top", "right"];
 
     //  name of style property to fadeout. for fill - "opacity", for path's stroke - "stroke-opacity" etc.
     const fadeProp = opt.fadeProp || "opacity";
 
+    // show/not show leaders
+    const showLeaders = opt.showLeaders;
     // placement
     const legend = this.shadowRoot.querySelector(".legend");
     positions.forEach((position) => (legend.style[position] = 0));
@@ -127,28 +130,40 @@ export default class Legend extends LitElement {
               opt.fadeoutNodes.forEach((node) => {
                 node.style[fadeProp] = 0.2;
               });
-              datum.node.style[fadeProp] = "";
 
-              leader.classList.add("-show");
-              const originRect = this.shadowRoot
-                .querySelector(".origin")
-                .getBoundingClientRect();
-              const legendRect = tr.getBoundingClientRect();
-              const targetRect = datum.node.getBoundingClientRect();
-              leader.style.left =
-                targetRect.x + targetRect.width * 0.5 - originRect.x + "px";
-              leader.style.width =
-                legendRect.x - targetRect.right + targetRect.width * 0.5 + "px";
-              const legendMiddle = legendRect.y + legendRect.height * 0.5;
-              const targetMiddle = targetRect.y + targetRect.height * 0.5;
-              if (legendMiddle < targetMiddle) {
-                leader.dataset.direction = "top";
-                leader.style.top = legendMiddle - originRect.y + "px";
-                leader.style.height = targetMiddle - legendMiddle + "px";
+              if (Array.isArray([...datum.node]) && datum.node.length !== 0) {
+                datum.node.forEach((item) => (item.style[fadeProp] = ""));
+              } else if (!Array.isArray([...datum.node])) {
+                datum.node.style[fadeProp] = "";
               } else {
-                leader.dataset.direction = "bottom";
-                leader.style.top = targetMiddle - originRect.y + "px";
-                leader.style.height = legendMiddle - targetMiddle + "px";
+                return;
+              }
+
+              if (showLeaders) {
+                leader.classList.add("-show");
+                const originRect = this.shadowRoot
+                  .querySelector(".origin")
+                  .getBoundingClientRect();
+                const legendRect = tr.getBoundingClientRect();
+                const targetRect = datum.node.getBoundingClientRect();
+                leader.style.left =
+                  targetRect.x + targetRect.width * 0.5 - originRect.x + "px";
+                leader.style.width =
+                  legendRect.x -
+                  targetRect.right +
+                  targetRect.width * 0.5 +
+                  "px";
+                const legendMiddle = legendRect.y + legendRect.height * 0.5;
+                const targetMiddle = targetRect.y + targetRect.height * 0.5;
+                if (legendMiddle < targetMiddle) {
+                  leader.dataset.direction = "top";
+                  leader.style.top = legendMiddle - originRect.y + "px";
+                  leader.style.height = targetMiddle - legendMiddle + "px";
+                } else {
+                  leader.dataset.direction = "bottom";
+                  leader.style.top = targetMiddle - originRect.y + "px";
+                  leader.style.height = legendMiddle - targetMiddle + "px";
+                }
               }
             }
           });


### PR DESCRIPTION
Legend プラグインに昨日追加
- Leaders を表示・非表示 のために `opt` に　`showLeaders` キー追加
- Fadeout しない  `node` が、単独のHTMLElement ではなく、 array の場合をも対応。（複数Elements をハイライトが必要のとき）