### PR TITLE
Fix tooltip

### DIFF
--- a/lib/ToolTip.js
+++ b/lib/ToolTip.js
@@ -25,6 +25,7 @@ export default class ToolTip extends LitElement {
           border-radius: 10px;
           opacity: 0;
           height: 0;
+          visibility: hidden;
           transition: height 0ms 250ms linear, opacity 200ms 0ms linear;
         }
         .tooltip::before {
@@ -42,6 +43,7 @@ export default class ToolTip extends LitElement {
         }
         .tooltip.-show {
           opacity: 1;
+          visibility: visible;
           height: 1.5em;
           transition: height 0ms 0ms linear, opacity 200ms 0ms linear,
             left 200ms, top 200ms;
@@ -66,7 +68,7 @@ export default class ToolTip extends LitElement {
           tooltip.textContent = node.dataset.tooltip;
         }
         tooltip.style.left = rect.x + rect.width * 0.5 - originRect.x + "px";
-        tooltip.style.top = rect.y - originRect.y + "px";
+        tooltip.style.top = rect.y - originRect.y - 5 + "px";
         tooltip.classList.add("-show");
       });
       node.addEventListener("mouseleave", () => {

--- a/lib/ToolTip.js
+++ b/lib/ToolTip.js
@@ -16,7 +16,6 @@ export default class ToolTip extends LitElement {
         .tooltip {
           padding: 2px 12px;
           position: absolute;
-          transition: all 0.2s;
           z-index: 10000;
           background-color: white;
           filter: drop-shadow(0 0.5px 1px black);
@@ -25,6 +24,8 @@ export default class ToolTip extends LitElement {
           transform: translate(-50%, -100%);
           border-radius: 10px;
           opacity: 0;
+          height: 0;
+          transition: height 0ms 250ms linear, opacity 200ms 0ms linear;
         }
         .tooltip::before {
           content: "";
@@ -41,6 +42,9 @@ export default class ToolTip extends LitElement {
         }
         .tooltip.-show {
           opacity: 1;
+          height: 1.5em;
+          transition: height 0ms 0ms linear, opacity 200ms 0ms linear,
+            left 200ms, top 200ms;
         }
       </style>
       <div class="origin"></div>


### PR DESCRIPTION
ToolTip が非表示の時にマウスの邪魔にならないように、`visibility: hidden`　に変更しました。