### PR TITLE
Venn diagram の Legend bugfix

### DIFF
--- a/stanzas/venn-diagram/index.js
+++ b/stanzas/venn-diagram/index.js
@@ -161,6 +161,7 @@ export default class VennStanza extends Stanza {
     });
     this.legend.setup(items, this.root.querySelector("main"), {
       fadeoutNodes: selectedDiagram.querySelectorAll(":scope > g"),
+      showLeaders: true,
     });
   }
 


### PR DESCRIPTION
Venn diagram stanza のLegend の`setup()`の使用方法更新しました。
（`showLeaders: true` 追加）