### PR TITLE
Get tooltip element only after mount

### DIFF
--- a/lib/ToolTip.js
+++ b/lib/ToolTip.js
@@ -54,8 +54,12 @@ export default class ToolTip extends LitElement {
     `;
   }
 
+  // Get tooltip element only after it was mounted
+  firstUpdated() {
+    this.tooltip = this.shadowRoot.querySelector(".tooltip");
+  }
+
   setup(nodes) {
-    const tooltip = this.shadowRoot.querySelector(".tooltip");
     nodes.forEach((node) => {
       node.addEventListener("mouseover", () => {
         const originRect = this.shadowRoot
@@ -63,16 +67,17 @@ export default class ToolTip extends LitElement {
           .getBoundingClientRect();
         const rect = node.getBoundingClientRect();
         if (node.dataset.tooltipHtml === "true") {
-          tooltip.innerHTML = node.dataset.tooltip;
+          this.tooltip.innerHTML = node.dataset.tooltip;
         } else {
-          tooltip.textContent = node.dataset.tooltip;
+          this.tooltip.textContent = node.dataset.tooltip;
         }
-        tooltip.style.left = rect.x + rect.width * 0.5 - originRect.x + "px";
-        tooltip.style.top = rect.y - originRect.y - 5 + "px";
-        tooltip.classList.add("-show");
+        this.tooltip.style.left =
+          rect.x + rect.width * 0.5 - originRect.x + "px";
+        this.tooltip.style.top = rect.y - originRect.y - 5 + "px";
+        this.tooltip.classList.add("-show");
       });
       node.addEventListener("mouseleave", () => {
-        tooltip.classList.remove("-show");
+        this.tooltip.classList.remove("-show");
       });
     });
   }


### PR DESCRIPTION
`tooltip.setup()` の中では、lit-element まだ　render されていないことがありますので、
`querySelector()` は　`undefined` を返すことがあります。
LifeCycle hook　`firstUpdated()` の中に  `querySelector()`　を移動しました。