### PR TITLE
Vega Barchart バグフィックス

### DIFF
--- a/stanzas/barchart/index.js
+++ b/stanzas/barchart/index.js
@@ -27,26 +27,37 @@ export default class Barchart extends Stanza {
 
     const { default: metadata } = await import("./metadata.json");
 
-    const defaultParams = new Map(
+    const params = new Map(
       metadata["stanza:parameter"].map((param) => [
         param["stanza:key"],
-        param["stanza:example"],
+        {
+          default: param["stanza:example"],
+          required: !!param["stanza:required"],
+        },
       ])
     );
 
+    for (const param in this.params) {
+      if (
+        params.get(param).required &&
+        typeof this.params[param] === "undefined"
+      ) {
+        throw new Error(`Required parameter ${param} is not defined`);
+      }
+    }
+
     const css = (key) => getComputedStyle(this.element).getPropertyValue(key);
     const chartType =
-      this.params["chart-type"] || defaultParams.get("chart-type");
+      this.params["chart-type"] || params.get("chart-type").default;
 
     //width,height,padding
-    const width = this.params["width"] || defaultParams.get("width");
-    const height = this.params["height"] || defaultParams.get("height");
+    const width = this.params["width"] || params.get("width").default;
+    const height = this.params["height"] || params.get("height").default;
     const padding = this.params["padding"];
 
     //data
-    const labelVariable =
-      this.params["category"] || defaultParams.get("category"); //x
-    const valueVariable = this.params["value"] || defaultParams.get("value"); //y
+    const labelVariable = this.params["category"]; //x
+    const valueVariable = this.params["value"]; //y
     const groupVariable = this.params["group-by"] //group
       ? this.params["group-by"]
       : "none"; //z
@@ -108,7 +119,7 @@ export default class Barchart extends Stanza {
         scale: "xscale",
         orient:
           this.params["xaxis-placement"] ||
-          defaultParams.get("xaxis-placement"),
+          params.get("xaxis-placement").default,
         domainColor: "var(--togostanza-axis-color)",
         domainWidth: css("--togostanza-axis-width"),
         grid: this.params["xgrid"] === "true",
@@ -134,7 +145,7 @@ export default class Barchart extends Stanza {
         labelPadding: this.params["xlabel-padding"],
         labelAlign:
           this.params["xlabel-alignment"] ||
-          defaultParams.get("xlabel-alignment"),
+          params.get("xlabel-alignment").default,
         labelLimit: this.params["xlabel-max-width"],
         encode: {
           labels: {
@@ -152,7 +163,7 @@ export default class Barchart extends Stanza {
         scale: "yscale",
         orient:
           this.params["yaxis-placement"] ||
-          defaultParams.get("yaxis-placement"),
+          params.get("yaxis-placement").default,
         domainColor: "var(--togostanza-axis-color)",
         domainWidth: css("--togostanza-axis-width"),
         grid: this.params["ygrid"] === "true",
@@ -178,7 +189,7 @@ export default class Barchart extends Stanza {
         labelPadding: this.params["ylabel-padding"],
         labelAlign:
           this.params["ylabel-alignment"] ||
-          defaultParams.get("ylabel-alignment"),
+          params.get("ylabel-alignment").default,
         labelLimit: this.params["ylabel-max-width"],
         zindex: 0,
         encode: {
@@ -188,7 +199,7 @@ export default class Barchart extends Stanza {
               angle: {
                 value:
                   this.params["ylabel-angle"] ||
-                  defaultParams.get("ylabel-angle"),
+                  params.get("ylabel-angle").default,
               },
               fill: { value: "var(--togostanza-label-font-color)" },
               font: {
@@ -346,7 +357,7 @@ export default class Barchart extends Stanza {
                     scale: "xscale",
                     band:
                       this.params["bar-width"] ||
-                      defaultParams.get("bar-width"),
+                      params.get("bar-width").default,
                   },
                   y: { scale: "yscale", field: "y0" },
                   y2: { scale: "yscale", field: "y1" },

--- a/stanzas/barchart/index.js
+++ b/stanzas/barchart/index.js
@@ -106,7 +106,9 @@ export default class Barchart extends Stanza {
     const axes = [
       {
         scale: "xscale",
-        orient: this.params["xaxis-placement"],
+        orient:
+          this.params["xaxis-placement"] ||
+          defaultParams.get("xaxis-placement"),
         domainColor: "var(--togostanza-axis-color)",
         domainWidth: css("--togostanza-axis-width"),
         grid: this.params["xgrid"] === "true",
@@ -342,7 +344,9 @@ export default class Barchart extends Stanza {
                   x: { scale: "xscale", field: labelVariable },
                   width: {
                     scale: "xscale",
-                    band: this.params["bar-width"],
+                    band:
+                      this.params["bar-width"] ||
+                      defaultParams.get("bar-width"),
                   },
                   y: { scale: "yscale", field: "y0" },
                   y2: { scale: "yscale", field: "y1" },

--- a/stanzas/barchart/index.js
+++ b/stanzas/barchart/index.js
@@ -142,9 +142,7 @@ export default class Barchart extends Stanza {
         titleFontWeight: css("--togostanza-title-font-weight"),
         titlePadding: this.params["xtitle-padding"],
         labelPadding: this.params["xlabel-padding"],
-        labelAlign:
-          this.params["xlabel-alignment"] ||
-          params.get("xlabel-alignment").default,
+        labelAlign: this.params["xlabel-alignment"],
         labelLimit: this.params["xlabel-max-width"],
         encode: {
           labels: {
@@ -186,9 +184,7 @@ export default class Barchart extends Stanza {
         titleFontWeight: css("--togostanza-title-font-weight"),
         titlePadding: this.params["ytitle-padding"],
         labelPadding: this.params["ylabel-padding"],
-        labelAlign:
-          this.params["ylabel-alignment"] ||
-          params.get("ylabel-alignment").default,
+        labelAlign: this.params["ylabel-alignment"],
         labelLimit: this.params["ylabel-max-width"],
         zindex: 0,
         encode: {

--- a/stanzas/barchart/index.js
+++ b/stanzas/barchart/index.js
@@ -25,18 +25,29 @@ export default class Barchart extends Stanza {
   async render() {
     appendCustomCss(this, this.params["custom-css-url"]);
 
+    const { default: metadata } = await import("./metadata.json");
+
+    const defaultParams = new Map(
+      metadata["stanza:parameter"].map((param) => [
+        param["stanza:key"],
+        param["stanza:example"],
+      ])
+    );
+
     const css = (key) => getComputedStyle(this.element).getPropertyValue(key);
-    const chartType = this.params["chart-type"];
+    const chartType =
+      this.params["chart-type"] || defaultParams.get("chart-type");
 
     //width,height,padding
-    const width = this.params["width"];
-    const height = this.params["height"];
+    const width = this.params["width"] || defaultParams.get("width");
+    const height = this.params["height"] || defaultParams.get("height");
     const padding = this.params["padding"];
 
     //data
-    const labelVariable = this.params["category"]; //x
-    const valueVariable = this.params["value"]; //y
-    const groupVariable = this.params["group-by"]
+    const labelVariable =
+      this.params["category"] || defaultParams.get("category"); //x
+    const valueVariable = this.params["value"] || defaultParams.get("value"); //y
+    const groupVariable = this.params["group-by"] //group
       ? this.params["group-by"]
       : "none"; //z
 
@@ -119,7 +130,9 @@ export default class Barchart extends Stanza {
         titleFontWeight: css("--togostanza-title-font-weight"),
         titlePadding: this.params["xtitle-padding"],
         labelPadding: this.params["xlabel-padding"],
-        labelAlign: this.params["xlabel-alignment"],
+        labelAlign:
+          this.params["xlabel-alignment"] ||
+          defaultParams.get("xlabel-alignment"),
         labelLimit: this.params["xlabel-max-width"],
         encode: {
           labels: {
@@ -135,7 +148,9 @@ export default class Barchart extends Stanza {
       },
       {
         scale: "yscale",
-        orient: this.params["yaxis-placement"],
+        orient:
+          this.params["yaxis-placement"] ||
+          defaultParams.get("yaxis-placement"),
         domainColor: "var(--togostanza-axis-color)",
         domainWidth: css("--togostanza-axis-width"),
         grid: this.params["ygrid"] === "true",
@@ -159,14 +174,20 @@ export default class Barchart extends Stanza {
         titleFontWeight: css("--togostanza-title-font-weight"),
         titlePadding: this.params["ytitle-padding"],
         labelPadding: this.params["ylabel-padding"],
-        labelAlign: this.params["ylabel-alignment"],
+        labelAlign:
+          this.params["ylabel-alignment"] ||
+          defaultParams.get("ylabel-alignment"),
         labelLimit: this.params["ylabel-max-width"],
         zindex: 0,
         encode: {
           labels: {
             interactive: true,
             update: {
-              angle: { value: this.params["ylabel-angle"] },
+              angle: {
+                value:
+                  this.params["ylabel-angle"] ||
+                  defaultParams.get("ylabel-angle"),
+              },
               fill: { value: "var(--togostanza-label-font-color)" },
               font: {
                 value: css("--togostanza-font-family"),
@@ -318,7 +339,12 @@ export default class Barchart extends Stanza {
               encode: {
                 enter: {
                   x: { scale: "xscale", field: labelVariable },
-                  width: { scale: "xscale", band: this.params["bar-width"] },
+                  width: {
+                    scale: "xscale",
+                    band:
+                      this.params["bar-width"] ||
+                      defaultParams.get("bar-width"),
+                  },
                   y: { scale: "yscale", field: "y0" },
                   y2: { scale: "yscale", field: "y1" },
                   fill: { scale: "color", field: groupVariable },

--- a/stanzas/barchart/index.js
+++ b/stanzas/barchart/index.js
@@ -315,6 +315,7 @@ export default class Barchart extends Stanza {
                 {
                   name: "bars",
                   from: { data: "facet" },
+
                   type: "rect",
                   encode: {
                     enter: {
@@ -341,9 +342,7 @@ export default class Barchart extends Stanza {
                   x: { scale: "xscale", field: labelVariable },
                   width: {
                     scale: "xscale",
-                    band:
-                      this.params["bar-width"] ||
-                      defaultParams.get("bar-width"),
+                    band: this.params["bar-width"],
                   },
                   y: { scale: "yscale", field: "y0" },
                   y2: { scale: "yscale", field: "y1" },

--- a/stanzas/barchart/index.js
+++ b/stanzas/barchart/index.js
@@ -47,8 +47,7 @@ export default class Barchart extends Stanza {
     }
 
     const css = (key) => getComputedStyle(this.element).getPropertyValue(key);
-    const chartType =
-      this.params["chart-type"] || params.get("chart-type").default;
+    const chartType = this.params["chart-type"];
 
     //width,height,padding
     const width = this.params["width"] || params.get("width").default;
@@ -197,9 +196,7 @@ export default class Barchart extends Stanza {
             interactive: true,
             update: {
               angle: {
-                value:
-                  this.params["ylabel-angle"] ||
-                  params.get("ylabel-angle").default,
+                value: this.params["ylabel-angle"],
               },
               fill: { value: "var(--togostanza-label-font-color)" },
               font: {

--- a/stanzas/barchart/metadata.json
+++ b/stanzas/barchart/metadata.json
@@ -105,6 +105,7 @@
     },
     {
       "stanza:key": "padding-outer",
+      "stanza:type": "number",
       "stanza:example": 0.4,
       "stanza:description": "Padding outside of bar group (0-1)"
     },

--- a/stanzas/barchart/metadata.json
+++ b/stanzas/barchart/metadata.json
@@ -173,11 +173,6 @@
       "stanza:description": "Y label angle (in degree)"
     },
     {
-      "stanza:key": "ylabel-angle",
-      "stanza:example": 0,
-      "stanza:description": "Y label angle (in degree)"
-    },
-    {
       "stanza:key": "xlabel-padding",
       "stanza:type": "number",
       "stanza:example": 5,


### PR DESCRIPTION
- required ではない param に`stanza:example` に記載された値に fallback するようにしました。
  (`0`の値の場合でも表示に問題ないの param を除く)　
  下記のparam に　fallback 動作を追加：
  - `width`と`height`
  - `xaxis-placement` と `yaxis-placement`
  - `bar-width`
- required param が省略すると`Required parameter <paramの名前> is not defined` エラーが投げられるようにしました。