### PR TITLE
Venn stanza Safari bugfix

### DIFF
--- a/stanzas/venn-diagram/index.js
+++ b/stanzas/venn-diagram/index.js
@@ -135,7 +135,6 @@ export default class VennStanza extends Stanza {
       // tooltip
       group.dataset.tooltip = `<strong>${labels.join("∩")}</strong>: ${count}`;
       group.dataset.tooltipHtml = true;
-      // this.setTooltip(group);
     });
     this.tooltip.setup(selectedDiagram.querySelectorAll("[data-tooltip]"));
 

--- a/stanzas/venn-diagram/index.js
+++ b/stanzas/venn-diagram/index.js
@@ -39,7 +39,7 @@ export default class VennStanza extends Stanza {
     this.renderTemplate({ template: "stanza.html.hbs" });
 
     // append tooltip, legend
-    const root = this.root.querySelector(":scope > div");
+    const root = this.root.querySelector("main");
     if (!this.tooltip) {
       this.tooltip = new ToolTip();
       root.append(this.tooltip);


### PR DESCRIPTION
Selector `:scope > div` not working in Safari, changed to `main`.