### PR TITLE
Treemap Safari bugfix

### DIFF
--- a/stanzas/treemap/index.js
+++ b/stanzas/treemap/index.js
@@ -257,7 +257,7 @@ function draw(el, dataset, opts) {
       .append("text")
       .attr("clip-path", (d) => d.clipUid)
       .attr("y", "1.5em")
-      .attr("x", "0.5rem")
+      .attr("x", "1em")
       .text((d) => {
         if (d === root) {
           return name(d);
@@ -265,14 +265,6 @@ function draw(el, dataset, opts) {
           return `${d.data.data.label}`;
         }
       });
-
-    // append expand icon
-    // node
-    //   .filter((d) => d !== root && d.children)
-    //   .append("image")
-    //   .attr("width", 10)
-    //   .attr("height", 10)
-    //   .attr("href", expandSvg);
 
     //adjust rectangles positions
     group.call(position, root, true, zoomInOut);
@@ -340,7 +332,7 @@ function draw(el, dataset, opts) {
             //set tspan to last added tspan and append word that didnt fit
             tspan = text
               .append("tspan")
-              .attr("x", x)
+              .attr("x", "1em")
               .attr("y", y)
               .attr("dy", ++lineNumber * lineHeight + dy + "em")
               .text(word);
@@ -352,7 +344,7 @@ function draw(el, dataset, opts) {
         .append("tspan")
         .attr("class", "number-label")
         .attr("dy", "1.6em")
-        .attr("x", "0.5rem")
+        .attr("x", "1.6em")
         .text((d) => format(d3.sum(d, (d) => d?.data?.data?.n || 0)));
     }
   }
@@ -372,32 +364,6 @@ function draw(el, dataset, opts) {
         })`;
       }
     });
-
-    // Placing icons in the middle of nodes
-    // group
-    //   .selectAll("image")
-    //   .attr("x", (d) => {
-    //     if (x(d.x0) === width) {
-    //       return (
-    //         (x(d.x0) + x(d.x1)) / 2 - x(d.x0) - iconWidth / 2 - 2 * borderWidth
-    //       );
-    //     } else {
-    //       return (
-    //         (x(d.x0) + x(d.x1)) / 2 - x(d.x0) - iconWidth / 2 - borderWidth
-    //       );
-    //     }
-    //   })
-    //   .attr("y", (d) => {
-    //     if (y(d.y0) === height) {
-    //       return (
-    //         (y(d.y0) + y(d.y1) - 2 * borderWidth) / 2 - y(d.y0) - iconHeight / 2
-    //       );
-    //     } else {
-    //       return (
-    //         (y(d.y0) + y(d.y1) - borderWidth) / 2 - y(d.y0) - iconHeight / 2
-    //       );
-    //     }
-    //   });
 
     a.select("rect")
       .attr("width", (d) => {


### PR DESCRIPTION
Safari や　FireFox のラベルの表示が故障していましたことを修正：
![image](https://user-images.githubusercontent.com/55772081/170652013-4205b4ab-651c-4d0a-88cc-5ad010a40f92.png)
