### PR TITLE
Feature/support case insesitive filter in pagination table

### DIFF
--- a/stanzas/pagination-table/app.vue
+++ b/stanzas/pagination-table/app.vue
@@ -718,7 +718,7 @@ function createColumnState(columnDef, values) {
     return {
       ...baseProps,
       parseValue(val) {
-        if (columnDef["sprintf"]) {
+        if (columnDef["sprintf"] && !isNaN(+val)) {
           return formattedValue(columnDef["sprintf"], val);
         } else {
           return String(val);

--- a/stanzas/pagination-table/app.vue
+++ b/stanzas/pagination-table/app.vue
@@ -712,7 +712,7 @@ function createColumnState(columnDef, values) {
 
     const search = (val) => {
       const q = query.value;
-      return q ? val.includes(q) : true;
+      return q ? (val.toLowerCase()).includes(q.toLowerCase()) : true;
     };
 
     return {
@@ -744,7 +744,7 @@ function searchByAllColumns(row, query) {
     return true;
   }
 
-  return row.some(({ value }) => String(value).includes(query));
+  return row.some(({ value }) => String(value).toLowerCase().includes(query.toLowerCase()));
 }
 
 function searchByEachColumn(row) {


### PR DESCRIPTION
ページネーションテーブルのフィルタをケースセンシティブではなくしました。
またついでに、sprintf 使用していて値が数値でない場合にエラーが出てましたが、エラー回避するようにしました。