### PR TITLE
Bump togostanza-utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12921,7 +12921,7 @@
     },
     "node_modules/togostanza-utils": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/togostanza/togostanza-utils.git#5c80953883070089f5f5ee7d39948d63c33a3445",
+      "resolved": "git+ssh://git@github.com/togostanza/togostanza-utils.git#de04d9095f9f97796e10dff6550bc37a2b2ada40",
       "dependencies": {
         "csv-stringify": "^6.0.5",
         "d3": "^7.0.1",
@@ -24411,7 +24411,7 @@
       }
     },
     "togostanza-utils": {
-      "version": "git+ssh://git@github.com/togostanza/togostanza-utils.git#5c80953883070089f5f5ee7d39948d63c33a3445",
+      "version": "git+ssh://git@github.com/togostanza/togostanza-utils.git#de04d9095f9f97796e10dff6550bc37a2b2ada40",
       "from": "togostanza-utils@github:togostanza/togostanza-utils",
       "requires": {
         "csv-stringify": "^6.0.5",


### PR DESCRIPTION
`togostanza-utils` バージョン更新
- `load-data` による Hash Table のスタイルのバグの修正
